### PR TITLE
Add missing TileMap collider import

### DIFF
--- a/korge-parallax/src/commonMain/kotlin/korlibs/korge/parallax/TileMap.kt
+++ b/korge-parallax/src/commonMain/kotlin/korlibs/korge/parallax/TileMap.kt
@@ -13,6 +13,7 @@ import korlibs.image.bitmap.*
 import korlibs.image.tiles.*
 import korlibs.image.tiles.TileSet
 import korlibs.math.geom.*
+import korlibs.math.geom.collider.*
 import kotlin.math.*
 
 inline fun Container.tileMap(


### PR DESCRIPTION
It seems like `import korlibs.math.geom.collider.*` import was missing, so the `HitTestDirection` was not resolved.